### PR TITLE
feat: add new statefulset for readonly data nodes

### DIFF
--- a/bitnami/elasticsearch/templates/_helpers.tpl
+++ b/bitnami/elasticsearch/templates/_helpers.tpl
@@ -59,10 +59,12 @@ Return the hostname of every ElasticSearch seed node
 {{- $masterFullname := include "elasticsearch.master.fullname" . }}
 {{- $coordinatingFullname := include "elasticsearch.coordinating.fullname" . }}
 {{- $dataFullname := include "elasticsearch.data.fullname" . }}
+{{- $dataroFullname := include "elasticsearch.dataro.fullname" . }}
 {{- $ingestFullname := include "elasticsearch.ingest.fullname" . }}
 {{- $masterFullname }}.{{ $releaseNamespace }}.svc.{{ $clusterDomain }},
 {{- $coordinatingFullname }}.{{ $releaseNamespace }}.svc.{{ $clusterDomain }},
 {{- $dataFullname }}.{{ $releaseNamespace }}.svc.{{ $clusterDomain }},
+{{- $dataroFullname }}.{{ $releaseNamespace }}.svc.{{ $clusterDomain }},
 {{- if .Values.ingest.enabled }}
 {{- $ingestFullname }}.{{ $releaseNamespace }}.svc.{{ $clusterDomain }},
 {{- end -}}
@@ -77,6 +79,18 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- .Values.data.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- printf "%s-%s" (include "common.names.fullname" .) .Values.data.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified dataro name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "elasticsearch.dataro.fullname" -}}
+{{- if .Values.dataro.fullnameOverride -}}
+{{- .Values.dataro.fullnameOverride | trunc 61 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" (include "common.names.fullname" .) .Values.dataro.name | trunc 61 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 
@@ -134,6 +148,17 @@ Get the initialization scripts Secret name.
     {{ default (include "elasticsearch.data.fullname" .) .Values.data.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.data.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+ Create the name of the data service account to use
+ */}}
+{{- define "elasticsearch.dataro.serviceAccountName" -}}
+{{- if .Values.dataro.serviceAccount.create -}}
+    {{ default (include "elasticsearch.dataro.fullname" .) .Values.dataro.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.dataro.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
 
@@ -282,6 +307,18 @@ Return the elasticsearch TLS credentials secret for data nodes.
     {{- printf "%s" (tpl $secretName $) -}}
 {{- else -}}
     {{- printf "%s-crt" (include "elasticsearch.data.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the elasticsearch TLS credentials secret for data nodes.
+*/}}
+{{- define "elasticsearch.dataro.tlsSecretName" -}}
+{{- $secretName := .Values.security.tls.dataro.existingSecret -}}
+{{- if $secretName -}}
+    {{- printf "%s" (tpl $secretName $) -}}
+{{- else -}}
+    {{- printf "%s-crt" (include "elasticsearch.dataro.fullname" .) -}}
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/elasticsearch/templates/coordinating-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/coordinating-statefulset.yaml
@@ -117,6 +117,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: MY_COMPONENT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: BITNAMI_DEBUG
               value: {{ ternary "true" "false" (or .Values.image.debug .Values.diagnosticMode.enabled) | quote }}
             - name: ELASTICSEARCH_CLUSTER_NAME
@@ -124,7 +128,7 @@ spec:
             - name: ELASTICSEARCH_CLUSTER_HOSTS
               value: {{ include "elasticsearch.hosts" . | quote }}
             - name: ELASTICSEARCH_TOTAL_NODES
-              value: {{ add (ternary .Values.master.autoscaling.minReplicas .Values.master.replicas .Values.master.autoscaling.enabled) (ternary .Values.data.autoscaling.minReplicas .Values.data.replicas .Values.data.autoscaling.enabled) | quote }}
+              value: {{ add (ternary .Values.master.autoscaling.minReplicas .Values.master.replicas .Values.master.autoscaling.enabled) (ternary .Values.data.autoscaling.minReplicas .Values.data.replicas .Values.data.autoscaling.enabled) (ternary .Values.dataro.autoscaling.minReplicas .Values.dataro.replicas .Values.dataro.autoscaling.enabled) | quote }}
             - name: ELASTICSEARCH_CLUSTER_MASTER_HOSTS
               {{- $elasticsearchMasterFullname := include "elasticsearch.master.fullname" . }}
               {{- $replicas := int (ternary .Values.master.autoscaling.minReplicas .Values.master.replicas .Values.master.autoscaling.enabled) }}
@@ -143,6 +147,8 @@ spec:
               value: "yes"
             - name: ELASTICSEARCH_NODE_TYPE
               value: "coordinating"
+            - name: ELASTICSEARCH_NODE_ATTRIBUTE_PURPOSE
+              value: "$(MY_COMPONENT_NAME)"
             {{- if .Values.security.enabled }}
             {{- include "elasticsearch.configure.security" . | nindent 12 }}
             {{- end }}

--- a/bitnami/elasticsearch/templates/data-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/data-statefulset.yaml
@@ -138,6 +138,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: MY_COMPONENT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['app.kubernetes.io/component']
             - name: BITNAMI_DEBUG
               value: {{ ternary "true" "false" (or .Values.image.debug .Values.diagnosticMode.enabled) | quote }}
             - name: ELASTICSEARCH_CLUSTER_NAME
@@ -145,7 +149,7 @@ spec:
             - name: ELASTICSEARCH_CLUSTER_HOSTS
               value: {{ include "elasticsearch.hosts" . | quote }}
             - name: ELASTICSEARCH_TOTAL_NODES
-              value: {{ add (ternary .Values.master.autoscaling.minReplicas .Values.master.replicas .Values.master.autoscaling.enabled) (ternary .Values.data.autoscaling.minReplicas .Values.data.replicas .Values.data.autoscaling.enabled) | quote }}
+              value: {{ add (ternary .Values.master.autoscaling.minReplicas .Values.master.replicas .Values.master.autoscaling.enabled) (ternary .Values.data.autoscaling.minReplicas .Values.data.replicas .Values.data.autoscaling.enabled) (ternary .Values.dataro.autoscaling.minReplicas .Values.dataro.replicas .Values.dataro.autoscaling.enabled) | quote }}
             {{- if .Values.plugins }}
             - name: ELASTICSEARCH_PLUGINS
               value: {{ .Values.plugins | quote }}
@@ -162,6 +166,8 @@ spec:
               value: "data"
             - name: ELASTICSEARCH_ADVERTISED_HOSTNAME
               value: "$(MY_POD_NAME).{{ include "elasticsearch.data.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+            - name: ELASTICSEARCH_NODE_ATTRIBUTE_PURPOSE
+              value: "$(MY_COMPONENT_NAME)"
             {{- if .Values.security.enabled }}
             {{- include "elasticsearch.configure.security" . | nindent 12 }}
             {{- end }}

--- a/bitnami/elasticsearch/templates/dataro-hpa.yaml
+++ b/bitnami/elasticsearch/templates/dataro-hpa.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.dataro.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "elasticsearch.dataro.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: data
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: {{ template "common.capabilities.statefulset.apiVersion" . }}
+    kind: StatefulSet
+    name: {{ include "elasticsearch.dataro.fullname" . }}
+  minReplicas: {{ .Values.dataro.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.dataro.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.dataro.autoscaling.targetCPU }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.dataro.autoscaling.targetCPU }}
+    {{- end }}
+    {{- if .Values.dataro.autoscaling.targetMemory }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.dataro.autoscaling.targetMemory }}
+    {{- end }}
+{{- end }}

--- a/bitnami/elasticsearch/templates/dataro-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/dataro-statefulset.yaml
@@ -1,79 +1,82 @@
 apiVersion: {{ template "common.capabilities.statefulset.apiVersion" . }}
 kind: StatefulSet
 metadata:
-  name: {{ include "elasticsearch.master.fullname" . }}
+  name: {{ include "elasticsearch.dataro.fullname" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: master
+    app.kubernetes.io/component: dataro
     ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
-    app: master
+    app: dataro
 spec:
   updateStrategy:
-    type: {{ .Values.master.updateStrategy.type }}
-    {{- if (eq "OnDelete" .Values.master.updateStrategy.type) }}
+    type: {{ .Values.dataro.updateStrategy.type }}
+    {{- if (eq "OnDelete" .Values.dataro.updateStrategy.type) }}
     rollingUpdate: null
+    {{- else if .Values.dataro.updateStrategy.rollingUpdatePartition }}
+    rollingUpdate:
+      partition: {{ .Values.dataro.updateStrategy.rollingUpdatePartition }}
     {{- end }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
-      app.kubernetes.io/component: master
+      app.kubernetes.io/component: dataro
   podManagementPolicy: Parallel
-  {{- if not .Values.master.autoscaling.enabled }}
-  replicas: {{ .Values.master.replicas }}
+  {{- if not .Values.dataro.autoscaling.enabled }}
+  replicas: {{ .Values.dataro.replicas }}
   {{- end }}
-  serviceName: {{ template "elasticsearch.master.fullname" . }}
+  serviceName: {{ template "elasticsearch.dataro.fullname" . }}
   template:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
-        app.kubernetes.io/component: master
+        app.kubernetes.io/component: dataro
         ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
-        app: master
-        {{- if .Values.master.podLabels }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.master.podLabels "context" $) | nindent 8 }}
+        app: dataro
+        {{- if .Values.dataro.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.dataro.podLabels "context" $) | nindent 8 }}
         {{- end }}
       annotations:
-        {{- if and (include "elasticsearch.createTlsSecret" .) (not .Values.security.tls.master.existingSecret) }}
+        {{- if and (include "elasticsearch.createTlsSecret" .) (not .Values.security.tls.dataro.existingSecret) }}
         checksum/tls: {{ include (print $.Template.BasePath "/tls-secret.yaml") . | sha256sum }}
         {{- end }}
-        {{- if .Values.master.podAnnotations }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.master.podAnnotations "context" $) | nindent 8 }}
+        {{- if .Values.dataro.podAnnotations }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.dataro.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
     spec:
       {{- include "elasticsearch.imagePullSecrets" . | nindent 6 }}
-      {{- if .Values.master.hostAliases }}
-      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.master.hostAliases "context" $) | nindent 8 }}
+      {{- if .Values.dataro.priorityClassName }}
+      priorityClassName: {{ .Values.dataro.priorityClassName | quote }}
       {{- end }}
-      {{- if .Values.master.schedulerName }}
-      schedulerName: {{ .Values.master.schedulerName }}
-      {{- end }}
-      {{- if .Values.master.priorityClassName }}
-      priorityClassName: {{ .Values.master.priorityClassName | quote }}
-      {{- end }}
-      {{- if .Values.master.affinity }}
-      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.master.affinity "context" $) | nindent 8 }}
+      {{- if .Values.dataro.affinity }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.dataro.affinity "context" $) | nindent 8 }}
       {{- else }}
       affinity:
-        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.master.podAffinityPreset "component" "master" "context" $) | nindent 10 }}
-        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.master.podAntiAffinityPreset "component" "master" "context" $) | nindent 10 }}
-        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.master.nodeAffinityPreset.type "key" .Values.master.nodeAffinityPreset.key "values" .Values.master.nodeAffinityPreset.values) | nindent 10 }}
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.dataro.podAffinityPreset "component" "dataro" "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.dataro.podAntiAffinityPreset "component" "dataro" "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.dataro.nodeAffinityPreset.type "key" .Values.dataro.nodeAffinityPreset.key "values" .Values.dataro.nodeAffinityPreset.values) | nindent 10 }}
       {{- end }}
-      {{- if .Values.master.nodeSelector }}
-      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.master.nodeSelector "context" $) | nindent 8 }}
+      {{- if .Values.dataro.hostAliases }}
+      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.dataro.hostAliases "context" $) | nindent 8 }}
       {{- end }}
-      {{- if .Values.master.tolerations }}
-      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.master.tolerations "context" $) | nindent 8 }}
+      {{- if .Values.dataro.schedulerName }}
+      schedulerName: {{ .Values.dataro.schedulerName }}
       {{- end }}
-      {{- if .Values.master.topologySpreadConstraints }}
-      topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.master.topologySpreadConstraints "context" $) | nindent 8 }}
+      {{- if .Values.dataro.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.dataro.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ template "elasticsearch.master.serviceAccountName" . }}
-      {{- if or .Values.master.podSecurityContext.enabled .Values.master.securityContext.enabled }}
+      {{- if .Values.dataro.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.dataro.tolerations "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.dataro.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.dataro.topologySpreadConstraints "context" $) | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ template "elasticsearch.dataro.serviceAccountName" . }}
+      {{- if or .Values.dataro.podSecurityContext.enabled .Values.dataro.securityContext.enabled }}
       securityContext:
-        {{- if .Values.master.podSecurityContext.enabled }}
-        {{- omit .Values.master.podSecurityContext "enabled" | toYaml | nindent 8 }}
+        {{- if .Values.dataro.podSecurityContext.enabled }}
+        {{- omit .Values.dataro.podSecurityContext "enabled" | toYaml | nindent 8 }}
         {{- else }}
-        fsGroup: {{ .Values.master.securityContext.fsGroup }}
+        fsGroup: {{ .Values.dataro.securityContext.fsGroup }}
         {{- end }}
       {{- end }}
-      {{- if or .Values.master.initContainers .Values.sysctlImage.enabled (and .Values.volumePermissions.enabled .Values.master.persistence.enabled) }}
+      {{- if or .Values.dataro.initContainers .Values.sysctlImage.enabled (and .Values.volumePermissions.enabled .Values.dataro.persistence.enabled) }}
       initContainers:
         {{- if .Values.sysctlImage.enabled }}
         ## Image that performs the sysctl operation to modify Kernel settings (needed sometimes to avoid boot errors)
@@ -92,7 +95,7 @@ spec:
           resources: {{- toYaml .Values.sysctlImage.resources | nindent 12 }}
           {{- end }}
         {{- end }}
-        {{- if and .Values.volumePermissions.enabled .Values.master.persistence.enabled }}
+        {{- if and .Values.volumePermissions.enabled .Values.dataro.persistence.enabled }}
         - name: volume-permissions
           image: {{ include "elasticsearch.volumePermissions.image" . }}
           imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
@@ -100,7 +103,7 @@ spec:
             - /bin/bash
             - -ec
             - |
-              chown -R {{ .Values.master.securityContext.runAsUser }}:{{ .Values.master.securityContext.fsGroup }} //bitnami/elasticsearch/data
+              chown -R {{ .Values.dataro.securityContext.runAsUser }}:{{ .Values.dataro.securityContext.fsGroup }} //bitnami/elasticsearch/data
           securityContext:
             runAsUser: 0
           {{- if .Values.volumePermissions.resources }}
@@ -110,20 +113,20 @@ spec:
             - name: data
               mountPath: "/bitnami/elasticsearch/data"
         {{- end }}
-        {{- if .Values.master.initContainers }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.master.initContainers "context" $) | nindent 8 }}
+        {{- if .Values.dataro.initContainers }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.dataro.initContainers "context" $) | nindent 8 }}
         {{- end }}
       {{- end }}
       containers:
         - name: elasticsearch
           image: {{ include "elasticsearch.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-          {{- if or .Values.master.containerSecurityContext.enabled .Values.master.securityContext.enabled }}
+          {{- if or .Values.dataro.containerSecurityContext.enabled .Values.dataro.securityContext.enabled }}
           securityContext:
-            {{- if .Values.master.containerSecurityContext.enabled }}
-            {{- omit .Values.master.containerSecurityContext "enabled" | toYaml | nindent 12 }}
-            {{ else }}
-            runAsUser: {{ .Values.master.securityContext.runAsUser }}
+            {{- if .Values.dataro.containerSecurityContext.enabled }}
+            {{- omit .Values.dataro.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+            {{- else }}
+            runAsUser: {{ .Values.dataro.securityContext.runAsUser }}
             {{- end }}
           {{- end }}
           {{- if .Values.diagnosticMode.enabled }}
@@ -147,14 +150,6 @@ spec:
               value: {{ include "elasticsearch.hosts" . | quote }}
             - name: ELASTICSEARCH_TOTAL_NODES
               value: {{ add (ternary .Values.master.autoscaling.minReplicas .Values.master.replicas .Values.master.autoscaling.enabled) (ternary .Values.data.autoscaling.minReplicas .Values.data.replicas .Values.data.autoscaling.enabled) (ternary .Values.dataro.autoscaling.minReplicas .Values.dataro.replicas .Values.dataro.autoscaling.enabled) | quote }}
-            - name: ELASTICSEARCH_CLUSTER_MASTER_HOSTS
-              {{- $elasticsearchMasterFullname := include "elasticsearch.master.fullname" . }}
-              {{- $replicas := int (ternary .Values.master.autoscaling.minReplicas .Values.master.replicas .Values.master.autoscaling.enabled) }}
-              value: {{ range $i, $e := until $replicas }}{{ $elasticsearchMasterFullname }}-{{ $e }} {{ end }}
-            - name: ELASTICSEARCH_MINIMUM_MASTER_NODES
-              value: {{ add (div (ternary .Values.master.autoscaling.minReplicas .Values.master.replicas .Values.master.autoscaling.enabled) 2) 1 | quote }}
-            - name: ELASTICSEARCH_ADVERTISED_HOSTNAME
-              value: "$(MY_POD_NAME).{{ include "elasticsearch.master.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
             {{- if .Values.plugins }}
             - name: ELASTICSEARCH_PLUGINS
               value: {{ .Values.plugins | quote }}
@@ -164,11 +159,13 @@ spec:
               value: {{ .Values.snapshotRepoPath | quote }}
             {{- end }}
             - name: ELASTICSEARCH_HEAP_SIZE
-              value: {{ .Values.master.heapSize | quote }}
+              value: {{ .Values.dataro.heapSize | quote }}
             - name: ELASTICSEARCH_IS_DEDICATED_NODE
               value: "yes"
             - name: ELASTICSEARCH_NODE_TYPE
-              value: "master"
+              value: "data"
+            - name: ELASTICSEARCH_ADVERTISED_HOSTNAME
+              value: "$(MY_POD_NAME).{{ include "elasticsearch.dataro.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
             - name: ELASTICSEARCH_NODE_ATTRIBUTE_PURPOSE
               value: "$(MY_COMPONENT_NAME)"
             {{- if .Values.security.enabled }}
@@ -194,53 +191,53 @@ spec:
             - name: transport
               containerPort: 9300
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.master.startupProbe.enabled }}
+          {{- if .Values.dataro.startupProbe.enabled }}
           startupProbe:
-            initialDelaySeconds: {{ .Values.master.startupProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.master.startupProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.master.startupProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.master.startupProbe.successThreshold }}
-            failureThreshold: {{ .Values.master.startupProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.dataro.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.dataro.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.dataro.startupProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.dataro.startupProbe.successThreshold }}
+            failureThreshold: {{ .Values.dataro.startupProbe.failureThreshold }}
             exec:
               command:
                 - /opt/bitnami/scripts/elasticsearch/healthcheck.sh
-          {{- else if .Values.master.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.master.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.dataro.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dataro.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.master.livenessProbe.enabled }}
+          {{- if .Values.dataro.livenessProbe.enabled }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.master.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.master.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.master.livenessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.master.livenessProbe.successThreshold }}
-            failureThreshold: {{ .Values.master.livenessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.dataro.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.dataro.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.dataro.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.dataro.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.dataro.livenessProbe.failureThreshold }}
             exec:
               command:
                 - /opt/bitnami/scripts/elasticsearch/healthcheck.sh
-          {{- else if .Values.master.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.master.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.dataro.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dataro.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.master.readinessProbe.enabled }}
+          {{- if .Values.dataro.readinessProbe.enabled }}
           readinessProbe:
-            initialDelaySeconds: {{ .Values.master.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.master.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.master.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.master.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.master.readinessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.dataro.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.dataro.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.dataro.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.dataro.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.dataro.readinessProbe.failureThreshold }}
             exec:
               command:
                 - /opt/bitnami/scripts/elasticsearch/healthcheck.sh
-          {{- else if .Values.master.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.master.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.dataro.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dataro.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
-          {{- if .Values.master.resources }}
-          resources: {{- toYaml .Values.master.resources | nindent 12 }}
+          {{- if .Values.dataro.resources }}
+          resources: {{- toYaml .Values.dataro.resources | nindent 12 }}
           {{- end }}
           volumeMounts:
             {{- if .Values.config }}
             - mountPath: /opt/bitnami/elasticsearch/config/elasticsearch.yml
-              name: config
+              name: "config"
               subPath: elasticsearch.yml
             {{- end }}
             {{- if .Values.extraConfig }}
@@ -248,8 +245,8 @@ spec:
               name: config
               subPath: my_elasticsearch.yml
             {{- end }}
-            - name: data
-              mountPath: /bitnami/elasticsearch/data
+            - name: "data"
+              mountPath: "/bitnami/elasticsearch/data"
             {{- if .Values.security.enabled }}
             - name: elasticsearch-certificates
               mountPath: /opt/bitnami/elasticsearch/config/certs
@@ -270,19 +267,19 @@ spec:
             - name: custom-init-scripts-secret
               mountPath: /docker-entrypoint-initdb.d/init-scripts-secret
             {{- end }}
-        {{- if .Values.master.sidecars }}
-        {{- include "common.tplvalues.render" ( dict "value" .Values.master.sidecars "context" $) | nindent 8 }}
+        {{- if .Values.dataro.sidecars }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.dataro.sidecars "context" $) | nindent 8 }}
         {{- end }}
       volumes:
         {{- if or .Values.config .Values.extraConfig }}
-        - name: config
+        - name: "config"
           configMap:
-            name: {{ include "common.names.fullname" . }}
+            name: {{ template "common.names.fullname" . }}
         {{- end }}
         {{- if .Values.security.enabled }}
         - name: elasticsearch-certificates
           secret:
-            secretName: {{ include "elasticsearch.master.tlsSecretName" . }}
+            secretName: {{ include "elasticsearch.dataro.tlsSecretName" . }}
             defaultMode: 256
         {{- end }}
         {{- if .Values.extraVolumes }}
@@ -304,32 +301,32 @@ spec:
             secretName: {{ template "elasticsearch.initScriptsSecret" . }}
             defaultMode: 0755
         {{- end }}
-{{- if not .Values.master.persistence.enabled }}
+{{- if not .Values.dataro.persistence.enabled }}
         - name: "data"
           emptyDir: {}
-{{- else if .Values.master.persistence.existingClaim }}
+{{- else if .Values.dataro.persistence.existingClaim }}
         - name: "data"
           persistentVolumeClaim:
-            claimName: {{ .Values.master.persistence.existingClaim }}
+            claimName: {{ .Values.dataro.persistence.existingClaim }}
 {{- else }}
   volumeClaimTemplates:
     - metadata:
         name: "data"
-        {{- if .Values.master.persistence.annotations }}
-        annotations: {{- toYaml .Values.master.persistence.annotations | nindent 10 }}
+        {{- if .Values.dataro.persistence.annotations }}
+        annotations: {{- toYaml .Values.dataro.persistence.annotations | nindent 10 }}
         {{- end }}
       spec:
-        accessModes: {{- toYaml .Values.master.persistence.accessModes | nindent 10 }}
-        {{ $storage := dict "global" .Values.global "local" .Values.master }}
-        {{ include "elasticsearch.storageClass" $storage  }}
+        accessModes: {{- toYaml .Values.dataro.persistence.accessModes | nindent 10 }}
+        {{ $storage := dict "global" .Values.global "local" .Values.dataro }}
+        {{ include "elasticsearch.storageClass" $storage }}
         resources:
           requests:
-            storage: {{ .Values.master.persistence.size | quote }}
-        {{- if .Values.master.persistence.selector }}
-        selector: {{- include "common.tplvalues.render" (dict "value" .Values.master.persistence.selector "context" $) | nindent 10 }}
-        {{- else if .Values.master.persistence.existingVolume }}
+            storage: {{ .Values.dataro.persistence.size | quote }}
+        {{- if .Values.dataro.persistence.selector }}
+        selector: {{- include "common.tplvalues.render" (dict "value" .Values.dataro.persistence.selector "context" $) | nindent 10 }}
+        {{- else if .Values.dataro.persistence.existingVolume }}
         selector:
           matchLabels:
-            volume: {{ .Values.master.persistence.existingVolume }}
+            volume: {{ .Values.dataro.persistence.existingVolume }}
         {{- end }}
 {{- end }}

--- a/bitnami/elasticsearch/templates/dataro-svc.yaml
+++ b/bitnami/elasticsearch/templates/dataro-svc.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "elasticsearch.dataro.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: dataro
+  annotations: {{ include "common.tplvalues.render" ( dict "value" .Values.dataro.service.annotations "context" $) | nindent 4 }}
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  ports:
+    - name: {{ include "elasticsearch.httpPortName" . }}
+      port: 9200
+      targetPort: {{ include "elasticsearch.httpPortName" . }}
+    - name: tcp-transport
+      port: 9300
+      targetPort: transport
+      nodePort: null
+  selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
+    app.kubernetes.io/component: dataro

--- a/bitnami/elasticsearch/templates/ingest-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/ingest-statefulset.yaml
@@ -123,7 +123,7 @@ spec:
             - name: ELASTICSEARCH_CLUSTER_HOSTS
               value: {{ include "elasticsearch.hosts" . | quote }}
             - name: ELASTICSEARCH_TOTAL_NODES
-              value: {{ add (ternary .Values.master.autoscaling.minReplicas .Values.master.replicas (eq .Values.master.autoscaling.enabled true)) (ternary .Values.data.autoscaling.minReplicas .Values.data.replicas (eq .Values.data.autoscaling.enabled true)) | quote }}
+              value: {{ add (ternary .Values.master.autoscaling.minReplicas .Values.master.replicas (eq .Values.master.autoscaling.enabled true)) (ternary .Values.data.autoscaling.minReplicas .Values.data.replicas (eq .Values.data.autoscaling.enabled true)) (ternary .Values.dataro.autoscaling.minReplicas .Values.dataro.replicas (eq .Values.dataro.autoscaling.enabled true)) | quote }}
             - name: ELASTICSEARCH_CLUSTER_MASTER_HOSTS
               {{- $elasticsearchMasterFullname := include "elasticsearch.master.fullname" . }}
               {{- $replicas := int (ternary .Values.master.autoscaling.minReplicas .Values.master.replicas (eq .Values.master.autoscaling.enabled true)) }}

--- a/bitnami/elasticsearch/templates/serviceaccount.yaml
+++ b/bitnami/elasticsearch/templates/serviceaccount.yaml
@@ -15,6 +15,15 @@ metadata:
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     role: data
 {{- end }}
+{{- if .Values.dataro.serviceAccount.create }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "elasticsearch.dataro.serviceAccountName" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    role: dataro
+{{- end }}
 {{- if .Values.master.serviceAccount.create }}
 ---
 apiVersion: v1

--- a/bitnami/elasticsearch/values.yaml
+++ b/bitnami/elasticsearch/values.yaml
@@ -126,6 +126,8 @@ security:
       existingSecret: ""
     data:
       existingSecret: ""
+    dataro:
+      existingSecret: ""
     ingest:
       existingSecret: ""
     coordinating:
@@ -821,6 +823,268 @@ data:
   ## @param data.name Data node pod name
   ##
   name: data
+  ## @param data.fullnameOverride String to fully override elasticsearch.data.fullname template with a string
+  ##
+  fullnameOverride: ""
+  ## @param data.replicas Desired number of Elasticsearch data nodes
+  ##
+  replicas: 2
+  ## @param data.hostAliases Add deployment host aliases
+  ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+  ##
+  hostAliases: []
+  ## @param data.schedulerName Name of the k8s scheduler (other than default)
+  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  schedulerName: ""
+  ## Update strategy for ElasticSearch Data statefulset
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
+  ## @param data.updateStrategy.type Update strategy for Data statefulset
+  ## @param data.updateStrategy.rollingUpdatePartition Partition update strategy for Data statefulset
+  ##
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdatePartition: ""
+  ## @param data.heapSize Data node heap size
+  ##
+  heapSize: 1024m
+  ## @param data.podAnnotations Annotations for data pods.
+  ##
+  podAnnotations: {}
+  ## @param data.podLabels Extra labels to add to Pod
+  ##
+  podLabels: {}
+  ## Pod Security Context for data pods.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  ## @param data.securityContext.enabled Enable security context for data pods
+  ## @param data.securityContext.fsGroup Group ID for the container for data pods
+  ## @param data.securityContext.runAsUser User ID for the container for data pods
+  ##
+  securityContext:
+    enabled: true
+    fsGroup: 1001
+    runAsUser: 1001
+  ## Pod Security Context for data pods.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  ## @param data.podSecurityContext.enabled Enable security context for data pods
+  ## @param data.podSecurityContext.fsGroup Group ID for the container for data pods
+  ##
+  podSecurityContext:
+    enabled: true
+    fsGroup: 1001
+  ## Container Security Context for data pods.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  ## @param data.containerSecurityContext.enabled Enable security context for data pods
+  ## @param data.containerSecurityContext.runAsUser User ID for the container for data pods
+  ##
+  containerSecurityContext:
+    enabled: true
+    runAsUser: 1001
+  ## @param data.podAffinityPreset Data Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ##
+  podAffinityPreset: ""
+  ## @param data.podAntiAffinityPreset Data Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+  ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ##
+  podAntiAffinityPreset: ""
+  ## Node affinity preset. Allowed values: soft, hard
+  ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+  ## @param data.nodeAffinityPreset.type Data Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+  ## @param data.nodeAffinityPreset.key Data Node label key to match Ignored if `affinity` is set.
+  ## @param data.nodeAffinityPreset.values Data Node label values to match. Ignored if `affinity` is set.
+  ##
+  nodeAffinityPreset:
+    type: ""
+    ## E.g.
+    ## key: "kubernetes.io/e2e-az-name"
+    ##
+    key: ""
+    ## E.g.
+    ## values:
+    ##   - e2e-az1
+    ##   - e2e-az2
+    ##
+    values: []
+
+  ## @param data.affinity Data Affinity for pod assignment
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## Note: podAffinityPreset, podAntiAffinityPreset, and  nodeAffinityPreset will be ignored when it's set
+  ##
+  affinity: {}
+  ## @param data.priorityClassName Data pods Priority Class Name
+  ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
+  ##
+  priorityClassName: ""
+  ## @param data.nodeSelector Data Node labels for pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+  ## @param data.tolerations Data Tolerations for pod assignment
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+  ## @param data.topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
+  ##
+  topologySpreadConstraints: []
+  ## Elasticsearch data container's resource requests and limits
+  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ## We usually recommend not to specify default resources and to leave this as a conscious
+  ## choice for the user. This also increases chances charts run on environments with little
+  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  ## @param data.resources.limits The resources limits for the container
+  ## @param data.resources.requests [object] The requested resources for the container
+  ##
+  resources:
+    ## Example:
+    ## limits:
+    ##    cpu: 100m
+    ##    memory: 2176Mi
+    limits: {}
+    requests:
+      cpu: 25m
+      memory: 2048Mi
+  ## Elasticsearch data container's startup probe
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ## @param data.startupProbe.enabled Enable/disable the startup probe (data nodes pod)
+  ## @param data.startupProbe.initialDelaySeconds Delay before startup probe is initiated (data nodes pod)
+  ## @param data.startupProbe.periodSeconds How often to perform the probe (data nodes pod)
+  ## @param data.startupProbe.timeoutSeconds When the probe times out (data nodes pod)
+  ## @param data.startupProbe.failureThreshold Minimum consecutive failures for the probe to be considered failed after having succeeded
+  ## @param data.startupProbe.successThreshold Minimum consecutive successes for the probe to be considered successful after having failed (data nodes pod)
+  ##
+  startupProbe:
+    enabled: false
+    initialDelaySeconds: 90
+    periodSeconds: 10
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 5
+  ## Elasticsearch data container's liveness probe
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ## @param data.livenessProbe.enabled Enable/disable the liveness probe (data nodes pod)
+  ## @param data.livenessProbe.initialDelaySeconds Delay before liveness probe is initiated (data nodes pod)
+  ## @param data.livenessProbe.periodSeconds How often to perform the probe (data nodes pod)
+  ## @param data.livenessProbe.timeoutSeconds When the probe times out (data nodes pod)
+  ## @param data.livenessProbe.failureThreshold Minimum consecutive failures for the probe to be considered failed after having succeeded
+  ## @param data.livenessProbe.successThreshold Minimum consecutive successes for the probe to be considered successful after having failed (data nodes pod)
+  ##
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 90
+    periodSeconds: 10
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 5
+  ## Elasticsearch data container's readiness probe
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ## @param data.readinessProbe.enabled Enable/disable the readiness probe (data nodes pod)
+  ## @param data.readinessProbe.initialDelaySeconds Delay before readiness probe is initiated (data nodes pod)
+  ## @param data.readinessProbe.periodSeconds How often to perform the probe (data nodes pod)
+  ## @param data.readinessProbe.timeoutSeconds When the probe times out (data nodes pod)
+  ## @param data.readinessProbe.failureThreshold Minimum consecutive failures for the probe to be considered failed after having succeeded
+  ## @param data.readinessProbe.successThreshold Minimum consecutive successes for the probe to be considered successful after having failed (data nodes pod)
+  ##
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 90
+    periodSeconds: 10
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 5
+  ## @param data.customStartupProbe Override default startup probe
+  ##
+  customStartupProbe: {}
+  ## @param data.customLivenessProbe Override default liveness probe
+  ##
+  customLivenessProbe: {}
+  ## @param data.customReadinessProbe Override default readiness probe
+  ##
+  customReadinessProbe: {}
+  ## @param data.initContainers Extra init containers to add to the Elasticsearch data pod(s)
+  ##
+  initContainers: []
+  ## @param data.sidecars Extra sidecar containers to add to the Elasticsearch data pod(s)
+  ##
+  sidecars: []
+  ## Service parameters for data-eligible node(s)
+  ##
+  service:
+    ## @param data.service.annotations Annotations for data-eligible nodes service
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+    ##
+    annotations: {}
+  ## Enable persistence using Persistent Volume Claims
+  ## ref: https://kubernetes.io/docs/user-guide/persistent-volumes/
+  ##
+  persistence:
+    ## @param data.persistence.enabled Enable persistence using a `PersistentVolumeClaim`
+    ##
+    enabled: true
+    ## @param data.persistence.storageClass Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    storageClass: ""
+    ## @param data.persistence.existingClaim Existing Persistent Volume Claim
+    ## If persistence is enable, and this value is defined,
+    ## then accept the value as an existing Persistent Volume Claim to which
+    ## the container should be bound
+    ##
+    existingClaim: ""
+    ## @param data.persistence.existingVolume Existing Persistent Volume for use as volume match label selector to the `volumeClaimTemplate`. Ignored when `data.persistence.selector` ist set.
+    ##
+    existingVolume: ""
+    ## @param data.persistence.selector Configure custom selector for existing Persistent Volume. Overwrites `data.persistence.existingVolume`
+    ## selector:
+    ##   matchLabels:
+    ##     volume:
+    selector: {}
+    ## @param data.persistence.annotations Persistent Volume Claim annotations
+    ##
+    annotations: {}
+    ## @param data.persistence.accessModes Persistent Volume Access Modes
+    ##
+    accessModes:
+      - ReadWriteOnce
+    ## @param data.persistence.size Persistent Volume Size
+    ##
+    size: 8Gi
+  ## Provide functionality to use RBAC
+  ##
+  serviceAccount:
+    ## @param data.serviceAccount.create Enable creation of ServiceAccount for the data node
+    ##
+    create: false
+    ## @param data.serviceAccount.name Name of the created serviceAccount
+    ## If not set and create is true, a name is generated using the fullname template
+    ##
+    name: ""
+  ## Autoscaling configuration
+  ## @param data.autoscaling.enabled Enable autoscaling for data replicas
+  ## @param data.autoscaling.minReplicas Minimum number of data replicas
+  ## @param data.autoscaling.maxReplicas Maximum number of data replicas
+  ## @param data.autoscaling.targetCPU Target CPU utilization percentage for data replica autoscaling
+  ## @param data.autoscaling.targetMemory Target Memory utilization percentage for data replica autoscaling
+  ##
+  autoscaling:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 11
+    targetCPU: ""
+    targetMemory: ""
+
+## Elasticsearch data node parameters
+##
+dataro:
+  ## @param data.name Data node pod name
+  ##
+  name: dataro
   ## @param data.fullnameOverride String to fully override elasticsearch.data.fullname template with a string
   ##
   fullnameOverride: ""


### PR DESCRIPTION
### Context
- To infrastructurally separate out read-only data nodes so that we can redirect and segregate some requests from each other, we need to add another statefulset.

### What is changing?
- Adding a new stateful set for data nodes identical in configuration to the original except named as "dataro".
- Also adding capability to let every node type know its type as an env variable (used in setting node attributes)